### PR TITLE
revert 45aae830d4f0df1a62bdfe6f4c7b789f75b8c0bc

### DIFF
--- a/docs/collaboration/README.md
+++ b/docs/collaboration/README.md
@@ -7,13 +7,13 @@
 
 All collaboration at ThreeFold is organized in circles, therefor make sure you get acquainted with the [ThreeFold Circles](/circles/README.md)
 
-- [How to contribute](/docs/collaboration/contributing_in_agile_org.md)
-- [Circles Roles](/docs/collaboration/circles_roles.md)
-- [Circles Tools](/docs/collaboration/circles_tools.md)
-- [Stories](/docs/collaboration/stories.md) the unit of work we reason with
-- [Trello Usage](/docs/collaboration/trello_usage.md)
+- [How to contribute](/collaboration/contributing_in_agile_org.md)
+- [Circles Roles](/collaboration/circles_roles.md)
+- [Circles Tools](/collaboration/circles_tools.md)
+- [Stories](/collaboration/stories.md) the unit of work we reason with
+- [Trello Usage](/collaboration/trello_usage.md)
 
 Also see:
-- [Story Pitfalls](/docs/collaboration/story_pitfalls.md)
-- [Head Of Mission Profile](/docs/collaboration/head_of_mission_profile.md)
-- [All other ThreeFold Web resources](/docs/web_resources.md)
+- [Story Pitfalls](/collaboration/story_pitfalls.md)
+- [Head Of Mission Profile](/collaboration/head_of_mission_profile.md)
+- [All other ThreeFold Web resources](/web_resources.md)


### PR DESCRIPTION
@timurgordon I had to revert this because this actually breaks the links on the Wiki page

Problem is - and I understand that this is the reason why you changed this - that by reverting the links don't work anymore in GitHub, where we need to add `/docs` to the URL, which is incompatible with how Docsify works, where the root is the /docs directory, not the actual root of the repo; quite annoying indeed...

When we switch to the new Digital Me webserver, not using Docsify anymore, this annoyance will be gone, until then we'll have to live with it :-)